### PR TITLE
Alert Maintenance

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -3,6 +3,7 @@ import { Client } from "discord.js";
 import CommandHandler from "./modules/interactions/commands/Manager";
 import ButtonHandler from "./modules/interactions/buttons/Manager";
 import EventHandler from "./modules/events/Manager";
+import AlertMaintainer from "./utils/AlertMaintainer";
 
 import "dotenv/config";
 
@@ -19,6 +20,7 @@ console.log("Bot is starting...");
 export default class Bot extends Client {
     commands!: CommandHandler;
     buttons!: ButtonHandler;
+    alertMaintainer!: AlertMaintainer;
 
     constructor() {
         super({
@@ -39,6 +41,7 @@ export default class Bot extends Client {
         (async () => {
             this.commands = new CommandHandler(this);
             this.buttons = new ButtonHandler(this);
+            this.alertMaintainer = new AlertMaintainer(this);
 
             const events = new EventHandler(this);
             events.load().catch(console.error);

--- a/src/events/Ready.ts
+++ b/src/events/Ready.ts
@@ -16,5 +16,6 @@ module.exports = class ReadyEventListener extends EventListener {
             client.commands.publish().catch(console.error);
             
             client.buttons.load().catch(console.error);
+            client.alertMaintainer.initiate().catch(console.error);
       }
 }

--- a/src/utils/AlertMaintainer.ts
+++ b/src/utils/AlertMaintainer.ts
@@ -1,0 +1,64 @@
+import Bot from "src/Bot";
+import Properties from "./Properties";
+import EmbedBuilds from "./EmbedBuilds";
+import ModAlert from "./ModAlert";
+import { TextChannel } from "discord.js";
+
+export default class AlertMaintainer {
+    public static minTimeToPostNotice = 7200e3; // (ms) Minimum time needed for staff to be pinged with an alert regarding untreated reports
+    public static updateInterval = 3600e3; // (ms) Time difference between alert checks
+    public static minTimeToDelete = 86400e3; // (ms) Minimum time needed for untreated reports to be deleted
+
+    client: Bot;
+
+    constructor(client: Bot) {
+        this.client = client;
+    }
+
+    public async initiate() {
+        this.checkModAlerts();
+        setInterval(this.checkModAlerts.bind(this), AlertMaintainer.updateInterval);
+    };
+
+    public async checkModAlerts() {
+        console.log(`<AlertMaintainer> Checking alerts at ${new Date().toTimeString()}`);
+
+        const modAlertsChannel = this.client.channels.cache.get(Properties.channels.alerts) as TextChannel;
+        const moderatorsChannel = this.client.channels.cache.get(Properties.channels.moderators) as TextChannel;
+
+        if (!modAlertsChannel || !moderatorsChannel) return;
+
+        modAlertsChannel.messages.fetch({ limit: 100 }).then(messages => {
+            const alertsToDelete = messages.filter(
+                (alertMessage) => Date.now() - alertMessage.createdTimestamp >= AlertMaintainer.minTimeToDelete
+            )
+
+            const untreatedReportExists = messages.some(
+                (alertMessage) => {
+                    const timeExisted = (Date.now() - alertMessage.createdTimestamp);
+                    return (
+                        timeExisted >= AlertMaintainer.minTimeToPostNotice 
+                        && timeExisted < AlertMaintainer.minTimeToDelete
+                    )
+                }
+            )
+
+            // Remove cached alerts from map (if any)
+            alertsToDelete.forEach(alertMessage => {
+                ModAlert.deleteModAlert(alertMessage.id, null, null)
+            })
+
+            // Delete very old reports
+            modAlertsChannel.bulkDelete(alertsToDelete, true);
+
+            if (untreatedReportExists) {
+                // Alert staff in "moderators" channel
+                const embed = EmbedBuilds.getPendingAlertsEmbed(modAlertsChannel);
+                moderatorsChannel.send({
+                    content: "@here Pending moderation alerts",
+                    embeds: [embed]
+                });
+            }
+        });
+    };
+};

--- a/src/utils/EmbedBuilds.ts
+++ b/src/utils/EmbedBuilds.ts
@@ -1,4 +1,4 @@
-import { MessageEmbed, VoiceState } from "discord.js";
+import { MessageEmbed, VoiceState, TextChannel } from "discord.js";
 
 export default class EmbedBuilds {
     public static getOnVoiceChannelJoinEmbed(newState: VoiceState): MessageEmbed {
@@ -48,5 +48,19 @@ export default class EmbedBuilds {
             .setDescription(`Member left \`#${oldState.channel?.name}\` (${oldState.channel})`)
             .setFooter({ text:`ID: ${oldState.member?.id}` })
             .setTimestamp();
+    }
+
+    public static getPendingAlertsEmbed(modAlertsChannel: TextChannel): MessageEmbed {
+        return new MessageEmbed()
+            .setColor(0x748bd8)
+            .setTitle("Moderation Alerts")
+            .setDescription(
+                `There are pending moderation alerts in ${modAlertsChannel.toString()}`
+                + `\n\nPlease remember to monitor moderation alerts frequently in order to avoid`
+                + ` an accumulation of messages (and untreated reports) in the channel`
+            )
+            .setFooter({
+                text: "This message appears whenever there are alerts that are over 2 hours old"
+            })
     }
  }

--- a/src/utils/Properties.ts
+++ b/src/utils/Properties.ts
@@ -14,6 +14,7 @@ export default class Properties {
         banRequestsQueue: "592580861543841802",
         messageLogs: "1024534308762947594",
         voiceLogs: "366624876544655360",
+        moderators: "150255535927721984",
         modCastText: "933975893599211570"
     }
 

--- a/src/utils/Properties.ts
+++ b/src/utils/Properties.ts
@@ -1,19 +1,8 @@
 export default class Properties {
     public static emojis = {
-        alert: "625429388229345280",
-        approve: "762388343253106688",
-        reject: "764268551473070080",
-        quickMute30: "760204798984454175",
-        quickMute60: "452813334429827072",
-        sweep: "783030737552670801"
     }
     
     public static channels = {
-        alerts: "785821764839669791",
-        commands: "150250250471342080",
-        banRequestsQueue: "592580861543841802",
-        messageLogs: "1024534308762947594",
-        voiceLogs: "366624876544655360",
         moderators: "150255535927721984",
         modCastText: "933975893599211570"
     }

--- a/src/utils/Properties.ts
+++ b/src/utils/Properties.ts
@@ -1,9 +1,20 @@
 export default class Properties {
     public static emojis = {
+        alert: "625429388229345280",
+        approve: "762388343253106688",
+        reject: "764268551473070080",
+        quickMute30: "760204798984454175",
+        quickMute60: "452813334429827072",
+        sweep: "783030737552670801"
     }
     
     public static channels = {
+        alerts: "785821764839669791",
+        commands: "150250250471342080",
         moderators: "150255535927721984",
+        banRequestsQueue: "592580861543841802",
+        messageLogs: "1024534308762947594",
+        voiceLogs: "366624876544655360",
         modCastText: "933975893599211570"
     }
 

--- a/src/utils/RoleUtils.ts
+++ b/src/utils/RoleUtils.ts
@@ -2,11 +2,11 @@ import { GuildMember } from "discord.js";
 
 export default class RoleUtils {
     public static roles = {
-        bot: "150075195971862528",
-        trialModerator: "218513797659230209",
-        moderator: "150093661231775744",
-        seniorModerator: "234520161720205312",
-        manager: "150074509393788929"
+        bot: "722582966261383188",
+        trialModerator: "926583545856675860",
+        moderator: "921934689550368773",
+        seniorModerator: "921934871314718810",
+        manager: "926583726719250483"
     }
 
     public static hasRole(member: GuildMember, roleId: string): boolean {

--- a/src/utils/RoleUtils.ts
+++ b/src/utils/RoleUtils.ts
@@ -2,11 +2,11 @@ import { GuildMember } from "discord.js";
 
 export default class RoleUtils {
     public static roles = {
-        bot: "722582966261383188",
-        trialModerator: "926583545856675860",
-        moderator: "921934689550368773",
-        seniorModerator: "921934871314718810",
-        manager: "926583726719250483"
+        bot: "150075195971862528",
+        trialModerator: "218513797659230209",
+        moderator: "150093661231775744",
+        seniorModerator: "234520161720205312",
+        manager: "150074509393788929"
     }
 
     public static hasRole(member: GuildMember, roleId: string): boolean {


### PR DESCRIPTION
`AlertMaintainer.ts` will assist in maintaining mod alerts through the following tasks:
- Staff are notified with `@here` if there are untreated reports that are over 2 hours old (or has existed for more than `minTimeToPostNotice`)
- Alerts are automatically cleared if they are over 24 hours old (or the time length explicitly set in `minTimeToDelete`)